### PR TITLE
Fix speed calculation function

### DIFF
--- a/cncserver.js
+++ b/cncserver.js
@@ -1555,7 +1555,7 @@ function getDurationFromDistance(distance, min) {
 
   // Use given speed over distance to calculate duration
   var speed = (cncserver.actualPen.state === 'draw' || cncserver.actualPen.state === 1) ? cncserver.botConf.get('speed:drawing') : cncserver.botConf.get('speed:moving');
-    speed = (speed/100) * cncserver.botConf.get('speed:max'); // Convert to steps from percentage
+    speed = (speed/100) * (cncserver.botConf.get('speed:max') - cncserver.botConf.get('speed:min')) + cncserver.botConf.get('speed:min'); // Convert to steps from percentage
 
     // Sanity check speed value
     speed = speed > cncserver.botConf.get('speed:max') ? cncserver.botConf.get('speed:max') : speed;


### PR DESCRIPTION
This will fix an issue in the way the speed calculation function calculates the correct step rate based on a percentage.

This image shows the output of the old function (red), and this version (blue).
![image](https://cloud.githubusercontent.com/assets/6558271/9028014/6ab65fc2-391f-11e5-940d-ca1fe36bc907.png)