### PR TITLE
Move all controller commands to machine config file

### DIFF
--- a/cncserver.js
+++ b/cncserver.js
@@ -354,11 +354,11 @@ function sendBotConfig() {
   // EBB Specific Config =================================
   if (cncserver.botConf.get('controller').name === 'EiBotBoard') {
     console.log('Sending EBB config...');
-    run('custom', 'EM,' + cncserver.botConf.get('speed:precision'));
+    run('custom', cmdstr('enablemotors', {p: cncserver.botConf.get('speed:precision')}));
 
     // Send twice for good measure
-    run('custom', 'SC,10,' + cncserver.botConf.get('servo:rate'));
-    run('custom', 'SC,10,' + cncserver.botConf.get('servo:rate'));
+    run('custom', cmdstr('configureservo', {r: cncserver.botConf.get('servo:rate')}));
+    run('custom', cmdstr('configureservo', {r: cncserver.botConf.get('servo:rate')}));
   }
 
   var isVirtual = cncserver.pen.simulation ? ' (simulated)' : '';
@@ -525,7 +525,7 @@ function serialPortReadyCallback() {
   cncserver.createServerEndpoint("/v1/motors", function(req, res){
     // Disable/unlock motors
     if (req.route.method === 'delete') {
-      run('custom', 'EM,0,0');
+      run('custom', cmdstr('disablemotors'));
       return [201, 'Disable Queued'];
     } else if (req.route.method === 'put') {
       if (req.body.reset === '1') {

--- a/machine_types/eggbot.ini
+++ b/machine_types/eggbot.ini
@@ -15,6 +15,11 @@ movexy = "SM,%d,%x,%y"
 movez = "SC,5,%z"
 togglez = "SP,%t"
 wait = "SM,%d,0,0"
+; Command to enable motors, with precision %p
+enablemotors = "EM,%p"
+disablemotors = "EM,0,0"
+; Command to configure servo, with rate %r
+configureservo = "SC,10,%r"
 
 [speed]
 ; 1 = 1/16 steps, 2 = 1/8, 3 = 1/4, 4 = 1/2, 5 = full steps

--- a/machine_types/watercolorbot.ini
+++ b/machine_types/watercolorbot.ini
@@ -15,6 +15,11 @@ movez = "SC,5,%z"
 togglez = "SP,%t"
 wait = "SM,%d,0,0"
 penpower = "SE,1,%p"
+; Command to enable motors, with precision %p
+enablemotors = "EM,%p"
+disablemotors = "EM,0,0"
+; Command to configure servo, with rate %r
+configureservo = "SC,10,%r"
 
 [speed]
 ; 1 = 1/16 steps, 2 = 1/8, 3 = 1/4, 4 = 1/2, 5 = full steps


### PR DESCRIPTION
This takes all (all - 1) hardcoded command strings and moves them to the machine config file. The function sendSetup (line 730) still uses a hardcoded string as this is a bit harder to sensibly move into a config file without switching to something more like what was discussed in #64.