### PR TITLE
Fix 'npm test' to run 'mocha' instead of non-existent Gruntfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,6 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "grunt": "*",
-    "grunt-cli": "*",
-    "grunt-mocha-test": "*",
-    "grunt-contrib-jshint": "*",
     "chai": "*",
     "request": "*"
   },
@@ -29,6 +25,6 @@
     "url": "https://github.com/techninja/cncserver.git"
   },
   "scripts": {
-    "test": "grunt --verbose"
+    "test": "mocha"
   }
 }


### PR DESCRIPTION
package.json includes a test script configured to call 'grunt
--verbose'. This appears to be incomplete, as a Gruntfile is not
included in this project. Replace with a call to 'mocha' which appears
to be the chosen test framework based on contents of package.json and
the test directory. Remove grunt package dependencies.