### PR TITLE
Add initial .travis.yml file for travis-ci support. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+node_js:
+  - "5.3"
+compiler: clang-3.6
+env:
+  - CXX=clang-3.6
+addons:
+  apt:
+    sources:
+      - llvm-toolchain-precise-3.6
+      - ubuntu-toolchain-r-test
+    packages:
+      - clang-3.6
+      - g++-4.8

--- a/cncserver.js
+++ b/cncserver.js
@@ -2022,9 +2022,7 @@ function connectSerial(options){
           }
 
           break;
-        case 'darwin':
-        case 'linux':
-        default:
+        default: // includes 'darwin', 'linux'
           // Match by exact productID and Manufacturer (Mac/*nix).
           if (portMaker == botMaker && portProductId == botProductId && autoDetect) {
             cncserver.gConf.set('serialPath', portNames[portID]);


### PR DESCRIPTION
This .travis.yml file seems to work (mostly) for getting automated builds/tests going. Note that this pull includes the same delinting patch as my last pull request techninja/cncserver#68. 'npm test' was failing the jshint check. I can rebase once the previous pull is done.

I say mostly because there seems to be some sort of race condition in stdout when travis runs the scratch tests. It is failing intermittently on my fork. When this gets pulled, perhaps it can be investigated further with others.