### PR TITLE
Remove paint tray area from WCB for pens

### DIFF
--- a/machine_types/watercolorbotpen.ini
+++ b/machine_types/watercolorbotpen.ini
@@ -1,0 +1,85 @@
+name = WaterColorBot-pen
+; WaterColorBot with offset for paint area removed for pen use
+
+; These are used to automatically detect/connect to the board. Very important!
+[controller]
+name = EiBotBoard
+manufacturer = SchmalzHaus
+vendorId = 0x04d8
+productId = 0xfd92
+baudRate = 9600
+position = relative
+ack = OK
+
+; Controller specific serial command format
+[controller.commands]
+movexy = "SM,%d,%x,%y"
+movez = "SC,5,%z"
+togglez = "SP,%t"
+wait = "SM,%d,0,0"
+penpower = "SE,1,%p"
+; Command to enable motors, with precision %p
+enablemotors = "EM,%p"
+disablemotors = "EM,0,0"
+; Command to configure servo, with rate %r
+configureservo = "SC,10,%r"
+
+[speed]
+; 1 = 1/16 steps, 2 = 1/8, 3 = 1/4, 4 = 1/2, 5 = full steps
+; Precision sets the size of every step!
+precision = 2
+; Minimum speed in steps per second
+min = 200
+; Maximum speed in steps per second
+max = 2000
+; Drawing (brush down) speed as percentage of maximum
+drawing = 75
+; Moving (brush up) speed as percentage of maximum
+moving = 75
+
+[maxArea]
+; Measured in steps
+width = 4965
+height = 3600
+
+; Position measured in percentage of maxArea
+[park]
+x = 0
+y = 0
+
+[workArea]
+; Also measured in steps
+top = 0
+left = 0
+
+[servo]
+; Highest allowed point
+max = 25000
+; Lowest allowed point
+min = 7500
+; Servo rate in pulses per channel, 0 for full speed
+rate = 65535
+; Amount of time (in milliseconds) a full movement from min to max takes
+duration = 340
+
+; Each value is a percentage between above min and max
+[servo.presets]
+; Highest lifted position (required)
+up = 70
+; Low position to paint/draw (required)
+draw = 30
+
+[penpower]
+max = 1023
+min = 0
+
+[tools]
+[tools.manualswap]
+x = 0
+y = 0
+wait = true
+
+[tools.manualresume]
+x = 0
+y = 0
+wait = false

--- a/machine_types/watercolorbotpen.ini
+++ b/machine_types/watercolorbotpen.ini
@@ -1,4 +1,4 @@
-name = WaterColorBot-pen
+name = "WaterColorBot no paint area"
 ; WaterColorBot with offset for paint area removed for pen use
 
 ; These are used to automatically detect/connect to the board. Very important!


### PR DESCRIPTION
When using a pen this makes getting the paper aligned with the pen much easier. With this change you can just position the pen at the top left corner of the paper.