### PR TITLE
Disable socket shortcuts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
+dist: trusty
 language: node_js
 node_js:
   - "5.3"
 compiler: clang-3.6
 env:
-  - CXX=clang-3.6
-addons:
-  apt:
-    sources:
-      - llvm-toolchain-precise-3.6
-      - ubuntu-toolchain-r-test
-    packages:
-      - clang-3.6
-      - g++-4.8
+  global:
+    - LLVM_VERSION=3.7.0
+    - LLVM_ARCHIVE_PATH=$HOME/clang+llvm.tar.xz
+
+before_install:
+  - wget http://llvm.org/releases/$LLVM_VERSION/clang+llvm-$LLVM_VERSION-x86_64-linux-gnu-ubuntu-14.04.tar.xz -O $LLVM_ARCHIVE_PATH
+  - mkdir $HOME/clang+llvm
+  - tar xf $LLVM_ARCHIVE_PATH -C $HOME/clang+llvm --strip-components 1
+  - export PATH=$HOME/clang+llvm/bin:$PATH

--- a/example/cncserver.client.api.js
+++ b/example/cncserver.client.api.js
@@ -60,7 +60,8 @@ cncserver.api = {
       options.state = value;
 
       // If we're on node and we have a socket, shortcut via WebSockets.
-      if (isNode && cncserver.global.socket) {
+      // TODO: FIX this as causes socket.io call stack overflows
+      if (isNode && cncserver.global.socket && false) {
         var data = {state: value, returnData: !!callback};
         cncserver.global.socket.emit('height', data);
         if (callback) {
@@ -207,7 +208,8 @@ cncserver.api = {
       point.y = point.y < 0 ? 0 : point.y;
 
       // If we're on node and we have a socket, shortcut via WebSockets.
-      if (isNode && cncserver.global.socket) {
+      // TODO: FIX this as causes socket.io call stack overflows
+      if (isNode && cncserver.global.socket && false) {
         if (typeof point.returnData === 'undefined') {
           point.returnData = !!callback;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cncserver",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A web based a web based CNC Server/Controller to drive @makersylvia's WaterColorBot and beyond",
   "main": "cncserver.js",
   "author": "techninja",


### PR DESCRIPTION
These are breaking on long/large sends (like the one line tree/fish) with constant linked callbacks. When there's time, these should be rolled back and some kind of stack callback breaker put in